### PR TITLE
added data to explore.ts

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -7,5 +7,5 @@
     <DarkMode />
     Fueled with Passion 🤙
     <!-- Nostri.chat below is placeholder until group hex id can be figured out-->
-    <!-- <NostriChat /> -->
+    <NostriChat />
 </div>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
     import { DarkMode } from "flowbite-svelte";
+    import NostriChat from "./NostriChat.svelte";
 </script>
 
 <div class='container border-t border-black/20 dark:border-white/20 mx-auto p-6 flex flex-row gap-6 items-center justify-center font-medium'>
     <DarkMode />
     Fueled with Passion 🤙
+    <!-- Nostri.chat below is placeholder until group hex id can be figured out-->
+    <!-- <NostriChat /> -->
 </div>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -12,6 +12,6 @@
             <a class="navLink no-underline md:text-xl font-semibold {$page.url.pathname.includes('explore') ? 'active' : ''}" href="/explore">Explore</a>
             
         </div>
-        <ProfileMenu on:logout on:login />
+         <ProfileMenu on:logout on:login />
     </div>
 </div>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -12,6 +12,6 @@
             <a class="navLink no-underline md:text-xl font-semibold {$page.url.pathname.includes('explore') ? 'active' : ''}" href="/explore">Explore</a>
             
         </div>
-         <ProfileMenu on:logout on:login />
+        <ProfileMenu on:logout on:login />
     </div>
 </div>

--- a/src/lib/components/NostriChat.svelte
+++ b/src/lib/components/NostriChat.svelte
@@ -1,5 +1,5 @@
 <script>
-    const groupID = "<GROUP_ID_IN_HEX_FORMAT>";
+    const groupID = "<0e0d47a7f2dfb147d1509f9067a1bd0b3816139abb61f1ba77c932599029add8>";
     const relays = ["wss://purplepag.es", "wss://relay.nostr.band", "wss://nos.lol", "wss://relay.snort.social", "wss://relay.damus.io"];
 
     import { onMount } from 'svelte';

--- a/src/lib/components/NostriChat.svelte
+++ b/src/lib/components/NostriChat.svelte
@@ -1,6 +1,6 @@
 <script>
     const groupID = "<GROUP_ID_IN_HEX_FORMAT>";
-    const relays = ["wss://relay.f7z.io", "wss://nos.lol", "wss://relay.nostr.band"];
+    const relays = ["wss://purplepag.es", "wss://relay.nostr.band", "wss://nos.lol", "wss://relay.snort.social", "wss://relay.damus.io"];
 
     import { onMount } from 'svelte';
   

--- a/src/lib/components/NostriChat.svelte
+++ b/src/lib/components/NostriChat.svelte
@@ -1,0 +1,33 @@
+<script>
+    const groupID = "<GROUP_ID_IN_HEX_FORMAT>";
+    const relays = ["wss://relay.f7z.io", "wss://nos.lol", "wss://relay.nostr.band"];
+
+    import { onMount } from 'svelte';
+  
+    onMount(() => {
+      // Load the bundle.js script dynamically
+      const script = document.createElement('script');
+      script.src = "https://nostri.chat/public/bundle.js";
+      script.dataset.chatType = "GROUP";
+      script.dataset.chatId = groupID;
+      script.dataset.relays = relays.join(',');
+  
+      script.onload = () => {
+        // Script loaded successfully
+      };
+  
+      script.onerror = () => {
+        // Error handling if script fails to load
+      };
+  
+      document.body.appendChild(script);
+  
+      // Load the bundle.css stylesheet
+      const link = document.createElement('link');
+      link.rel = "stylesheet";
+      link.href = "https://nostri.chat/public/bundle.css";
+  
+      document.head.appendChild(link);
+    });
+  </script>
+  

--- a/src/lib/data/explore.ts
+++ b/src/lib/data/explore.ts
@@ -22,53 +22,6 @@ export const exploreLinks: App.LinkList[] = [
         ]
     },
     {
-        title: 'Audio/Video Streaming',
-        links: [
-            {
-                title: 'Fountain',
-                url: 'https://www.fountain.fm/',
-                description: 'The podcast app that pays.'
-            },
-            {
-                title: 'Nostr Nests',
-                url: 'https://nostrnests.com/',
-                description: 'Host and join audio spaces.'
-            },
-            {
-                title: 'Stemstr',
-                url: 'https://stemstr.app/',
-                description:
-                    'A social experience for music artists to connect, collaborate and share amazing music - powered by nostr.'
-            },
-            {
-                title: 'Vida',
-                url: 'https://vida.page',
-                description: 'Connect via paid messages, calls and live streams.'
-            },
-            {
-                title: 'Wavlake',
-                url: 'https://www.wavlake.com/',
-                description: 'Turn up the value for your biggest fans.'
-            },
-            {
-                title: 'Wavman',
-                url: 'https://www.wavman.app',
-                description: 'An open-source music player built for Nostr.'
-            },
-            {
-                title: 'Zapstr.live',
-                url: 'https://zapstr.live',
-                description: 'Sign in, listen, upload and chat.'
-            },
-            {
-                title: 'Zap.stream',
-                url: 'https://zap.stream/',
-                description:
-                    'View current streams and start new live streams while chatting, zapping and interacting.'
-            }
-        ]
-    },
-    {
         title: 'Browser Extensions',
         links: [
             {
@@ -81,6 +34,11 @@ export const exploreLinks: App.LinkList[] = [
                 url: 'https://www.getflamingo.org/',
                 description:
                     'A Chrome compatible browser extension that makes interacting with Nostr apps safe and easy.'
+            },
+            {   
+                title: 'Keys.Band',
+                url: 'https://keys.band/',
+                description: 'Keep your keys safe with the best Nostr Extension for Chromium Browsers.'
             },
             {
                 title: 'Nos2x',
@@ -107,6 +65,11 @@ export const exploreLinks: App.LinkList[] = [
                 title: 'NostrChat',
                 url: 'https://www.nostrchat.io',
                 description: 'A decentralized chat application.'
+            },
+            {
+                title: 'Nostri.chat',
+                url: 'https://nostri.chat/',
+                description: 'A chat widget for your site, powered by Nostr.'
             }
         ]
     },
@@ -229,12 +192,48 @@ export const exploreLinks: App.LinkList[] = [
         ]
     },
     {
+        title: 'Music and Podcasting',
+        links: [
+            {
+                title: 'Fountain',
+                url: 'https://www.fountain.fm/',
+                description: 'The podcast app that pays.'
+            },
+            {
+                title: 'Stemstr',
+                url: 'https://stemstr.app/',
+                description:
+                    'A social experience for music artists to connect, collaborate and share amazing music - powered by nostr.'
+            },
+            {
+                title: 'Wavlake',
+                url: 'https://www.wavlake.com/',
+                description: 'Turn up the value for your biggest fans.'
+            },
+            {
+                title: 'Wavman',
+                url: 'https://www.wavman.app',
+                description: 'An open-source music player built for Nostr.'
+            },
+            {
+                title: 'Zapstr.live',
+                url: 'https://zapstr.live',
+                description: 'Sign in, listen, upload and chat.'
+            }
+        ]
+    },
+    {
         title: 'News',
         links: [
             {
                 title: 'Nostr Report',
                 url: 'https://nostr.report/',
                 description: 'Your #1 source for Daily Nostr news. Built by plebs, for plebs.'
+            },
+            {
+                title: 'Stacker News',
+                url: 'https://stacker.news/',
+                description: "It's like Hacker News but we pay you Bitcoin."
             }
         ]
     },
@@ -413,6 +412,11 @@ export const exploreLinks: App.LinkList[] = [
                 description: 'Host and join audio spaces.'
             },
             {
+                title: 'Nostr View',
+                url: 'https://nostrview.com',
+                description: 'Search popular notes, events and relays.'
+            },
+            {
                 title: 'Plebstr',
                 url: 'https://plebstr.com',
                 description: 'A friendly Nostr client, reimagined.'
@@ -457,6 +461,27 @@ export const exploreLinks: App.LinkList[] = [
                 title: 'Zap.stream',
                 url: 'https://zap.stream',
                 description: 'A Nostr native streaming provider.'
+            }
+        ]
+    },
+    {
+        title: 'Streaming',
+        links: [
+            {
+                title: 'Nostr Nests',
+                url: 'https://nostrnests.com/',
+                description: 'Host and join audio spaces.'
+            },
+            {
+                title: 'Vida',
+                url: 'https://vida.page',
+                description: 'Connect via paid messages, calls and live streams.'
+            },
+            {
+                title: 'Zap.stream',
+                url: 'https://zap.stream/',
+                description:
+                    'View current streams and start new live streams while chatting, zapping and interacting.'
             }
         ]
     },

--- a/src/lib/data/learn.ts
+++ b/src/lib/data/learn.ts
@@ -35,6 +35,11 @@ export const learnLinks: App.LinkList[] = [
                 title: 'Nostr Dev Kit',
                 url: 'https://ndkit.com',
                 description: 'The fastest way to build with Nostr.'
+            },
+            {
+                title: 'Nostr Design',
+                url: 'https://nostrdesign.org/',
+                description: 'Comprehensive resources and guide to help you design better clients.'
             }
         ]
     },


### PR DESCRIPTION
I have updated the explore.ts file mainly, also added a NostriChat.svelte component (currently have it inactive)..

I am not sure if I have the NostriChat component setup correctly (pretty sure I don't actually). 

Looks like it needs a group id hex, although maybe that is accomplished through the NIP-07 sign in? Or do I provide my own - that would be specific to whynostr?

 It looks like NIP28 is the correct NIP for group chat. Here's link

[https://github.com/nostr-protocol/nips/blob/master/28.md](url) 
I am going to check it out in more detail asap.

Do you have any thoughts/ideas on that in the meantime?

Also, any feedback on the new explore page. I have been updating the sites and categories. Do they seem cohesive and correct? 

I am trying to add more from the Nostrverse (plus orange pill friendly) but hoping to not get too off track, so I hope some of the new sites I have added don't detract (such as the Other Stuff category or some links within Commerce)